### PR TITLE
Ensure dim param is appended to url if specified

### DIFF
--- a/bowshock/earth.py
+++ b/bowshock/earth.py
@@ -58,7 +58,7 @@ def imagery(lon=None, lat=None, dim=None, date=None, cloud_score=None):
         try:
             validate_float(dim)
             dim = decimal.Decimal(dim)
-            base_url + "dim=" + str(dim) + "&"
+            base_url += "dim=" + str(dim) + "&"
         except:
             raise ValueError("imagery endpoint expects dim to be a float")
 


### PR DESCRIPTION
This slight adjustment will fix #4.

HOWEVER, I suggest NOT merging this into the master branch just yet. It seems that the `dim` parameter causes some kind of error in the API endpoint:

```
$ curl "http://api.data.gov/nasa/planetary/earth/imagery?lon=100.75&lat=1.5&date=2015-07-04&cloud_score=True&api_key=DEMO_KEY"
{"date": "2015-06-15T03:28:16", "url": "https://earthengine.googleapis.com/api/thumb?thumbid=4c3e852191f53f5653732b91feae7efd&token=d9967e5c873d725ba22f4314728a63ab", "cloud_score": 1.0, "id": "LC8_L1T_TOA/LC81270592015166LGN00"}
```

Compare the nice output from above to the nasty output below (when the `dim` parameter is included):

```
$ curl "http://api.data.gov/nasa/planetary/earth/imagery?lon=100.75&lat=1.5&dim=0.025&date=2015-07-04&cloud_score=True&api_key=DEMO_KEY"
{"message": "Admins have been notified.", "error": "unsupported operand type(s) for /: 'unicode' and 'int'"}
```

Argh -- that does not look good!

On the NASA API page, they list Jason Duley (jason.duley@nasa.gov) as the contact. Should we reach out to Jason to see if we have uncovered a bug in this endpoint?
