### PR TITLE
Point NASA API links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@
 bowshock is an all-in-one wrapper for NASA API's.
 Here is a list of currently supported API's :
 
-* NASA [Earth API](https://data.nasa.gov/developer/external/planetary/#imagery)
-* NASA [APOD API](https://data.nasa.gov/developer/external/planetary/#address)
-* NASA [Patents API](https://data.nasa.gov/developer/external/planetary/#sounds)
-* NASA [Earth Temperature Anomalies API](https://data.nasa.gov/developer/external/planetary/#coordinates)
+* NASA [Earth API](https://api.nasa.gov/api.html#earth)
+* NASA [APOD (Astronomy Picture of the Day) API](https://api.nasa.gov/api.html#apod)
+* NASA [Patents API](https://api.nasa.gov/api.html#patents)
+* NASA [Earth Temperature Anomalies API](https://api.nasa.gov/api.html#earth-temperature-anomalies)
 * [Asterank API](http://www.asterank.com/api)
 * [HelioViewer API](http://helioviewer.org/api/docs/v1/)
-* [Mars Weather API](http://marsweather.ingenology.com/#get_started)
-* [MODIS API](http://daac.ornl.gov/MODIS/MODIS-menu/modis_webservice.html)
+* [MAAS (Mars Weather) API](http://marsweather.ingenology.com/#get_started)
+* [MODIS (Land, Atmosphere and Ocean Data) API](http://daac.ornl.gov/MODIS/MODIS-menu/modis_webservice.html)
 * [Skymorph API](http://www.asterank.com/skymorph)
 * [Star API](http://hacktheuniverse.github.io/star-api/)
 * [Techport API](https://data.nasa.gov/developer/external/techport/techport-api.pdf)


### PR DESCRIPTION
Small change introduced with this PR. It seems that the NASA documentation for the Earth, APOD, Patents and Earth Temperature Anomalies APIs has changed -- the updated links point to NASA's examples.
