### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ===========
 
-##About
+## About
 
 bowshock is an all-in-one wrapper for NASA API's.
 Here is a list of currently supported API's :
@@ -25,7 +25,7 @@ Here is a list of currently supported API's :
 * [Techport API](https://data.nasa.gov/developer/external/techport/techport-api.pdf)
 * [PredictTheSky API](http://predictthesky.org/developers.html)
 
-##Install
+## Install
 
 Standart Procedure
 
@@ -45,15 +45,15 @@ Earth Temperature Anomalies|
 **The rest does not require an API key for usage.**
 Get your NASA API KEY from : https://data.nasa.gov/developer/external/planetary/#apply-for-an-api-key
 
-####Setting up the API Key
+#### Setting up the API Key
 ===================
 set an environment varible NASA_API_KEY which is equal to your key string
 
 
-##Usage
+## Usage
 
 -
-#####Apod
+##### Apod
 ```python
 from bowshock import apod
 
@@ -63,7 +63,7 @@ apod.apod(date="2015-02-02", concept_tags=True)
 ```
 
 -
-#####Asterank
+##### Asterank
 ```python
 from bowshock import asterank
 
@@ -78,7 +78,7 @@ asterank.asterank(
 
 
 -
-#####Earth
+##### Earth
 ```python
 from bowshock import earth
 
@@ -93,7 +93,7 @@ earth.assets(lon=100.75, lat=1.6, begin="2015-02-02", end="2015-02-10")
 ```
 
 -
-#####HelioViewer
+##### HelioViewer
 ```python
 from bowshock import helioviewer
 
@@ -106,7 +106,7 @@ helioviewer.getjp2header(Id=7654321)
 
 
 -
-#####MAAS
+##### MAAS
 ```python
 from bowshock import maas
 
@@ -118,7 +118,7 @@ maas.maas_latest()
 ```
 
 -
-#####Patents
+##### Patents
 ```python
 from bowshock import patents
 
@@ -129,7 +129,7 @@ patents.patents(query="temperature", concept_tags=True, limit=5)
 
 
 -
-#####PredictTheSky
+##### PredictTheSky
 ```python
 from bowshock import predictthesky
 
@@ -140,7 +140,7 @@ predictthesky.space_events(lon=100.75, lat=1.5)
 
 
 -
-#####Star API
+##### Star API
 ```python
 from bowshock import star
 
@@ -173,7 +173,7 @@ skymorph.search_target_obj("J99TS7A")
 
 
 -
-#####temperature anomalies
+##### temperature anomalies
 ```python
 from bowshock import temperature_anomalies
 
@@ -185,20 +185,20 @@ temperature_anomalies.coordinate(lon=100.3, lat=1.6, begin="1990", end="2005")
 
 
 -
-#####techport
+##### techport
 ```python
 from bowshock import techport
 
 techport.techport(Id="4795")
 
 ```
-##Contributors
+## Contributors
 
 * [Dan Wagner](https://github.com/danwagnerco)
 <br>
 
-##TODO
+## TODO
 - Lance-Modis API - http://lance-modis.eosdis.nasa.gov/user_services/api-lance.html
 
-##BTW What is "bowshock"?
+## BTW What is "bowshock"?
 ![Screenshot](https://raw.githubusercontent.com/emirozer/bowshock/master/docs/bowshock.jpg)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
